### PR TITLE
Closes #62 Port: Migrate enzyme-folding prediction module from Python to Rust

### DIFF
--- a/__src1/example_usage_radix_sort.f90
+++ b/__src1/example_usage_radix_sort.f90
@@ -1,0 +1,52 @@
+!> Test program for the Radix Sort algorithm
+!!
+!!  Created by: Ramy-Badr-Ahmed (https://github.com/Ramy-Badr-Ahmed)
+!!  in Pull Request: #11
+!!  https://github.com/TheAlgorithms/Fortran/pull/11
+!!
+!!  Please mention me (@Ramy-Badr-Ahmed) in any issue or pull request
+!!  addressing bugs/corrections to this file. Thank you!
+!!
+!! This program demonstrates the use of the radix_sort_module by sorting an array of integers.
+!! The base parameter affects the internal digit processing but does not change the final sorted order
+!! of decimal integers. The output is always in decimal form.
+
+program test_radix_sort
+    use radix_sort_module
+    implicit none
+    integer, dimension(10) :: array
+    integer :: n, i
+    integer, parameter :: base10 = 10, base2 = 2, base16 = 16
+
+    ! Test for base 10
+    print *, "Testing Radix Sort with base 10:"
+    array = (/170, 45, 75, 90, 802, 24, 2, 66, 15, 40/)
+    n = size(array)
+    call radix_sort(array, n, base10)
+    print *, "Sorted array in base 10:"
+    do i = 1, n
+        print *, array(i)
+    end do
+
+    ! Test for base 2
+    print *, "Testing Radix Sort with base 2:"
+    array = (/1010, 1101, 1001, 1110, 0010, 0101, 1111, 0110, 1000, 0001/) ! Binary values whose decimal: (/ 10, 13, 9, 14, 2, 5, 15, 6, 8, 1 /)
+    n = size(array)
+    call radix_sort(array, n, base2)
+    print *, "Sorted binary array in Decimal:"
+    do i = 1, n
+        print *, array(i)
+    end do
+
+    ! Test for base 16
+    print *, "Testing Radix Sort with base 16:"
+    array = (/171, 31, 61, 255, 16, 5, 211, 42, 180, 0/)  ! Hexadecimal values as decimal
+    n = size(array)
+    call radix_sort(array, n, base16)
+    print *, "Sorted hexadecimal array in Decimal:"
+    do i = 1, n
+        print *, array(i)
+    end do
+
+end program test_radix_sort
+

--- a/__src1/kalman_filter.r
+++ b/__src1/kalman_filter.r
@@ -1,0 +1,32 @@
+library(Metrics)
+set.seed(123)
+num_obs <- 100
+true_returns <- rnorm(num_obs, mean = 0.001, sd = 0.01)
+observed_prices <- cumprod(1 + true_returns) * 100
+noise <- rnorm(num_obs, mean = 0, sd = 0.1)
+noisy_prices <- observed_prices + noise
+# Kalman filter implementation
+kalman_filter <- function(observed_prices) {
+  state <- c(observed_prices[1], 0)
+  P <- matrix(c(1, 0, 0, 1), nrow = 2)
+  Q <- matrix(c(0.0001, 0, 0, 0.0001), nrow = 2)
+  R <- 0.1
+  A <- matrix(c(1, 1, 0, 1), nrow = 2)
+  H <- matrix(c(1, 0), nrow = 1)
+  filtered_states <- matrix(0, nrow = length(observed_prices), ncol = 2)
+  for (i in 1:length(observed_prices)) {
+    state_pred <- A %*% state
+    P_pred <- A %*% P %*% t(A) + Q
+    K <- P_pred %*% t(H) %*% solve(H %*% P_pred %*% t(H) + R)
+    state <- state_pred + K %*% (observed_prices[i] - H %*% state_pred)
+    P <- (matrix(1, nrow = 2, ncol = 2) - K %*% H) %*% P_pred
+    filtered_states[i, ] <- state
+  }
+  return(list(filtered_states = filtered_states, state_pred = state_pred, P_pred = P_pred))
+}
+result <- kalman_filter(noisy_prices)
+plot(observed_prices, type = "l", col = "blue", lwd = 2, main = "Kalman Filter")
+lines(result$filtered_states[, 1], type = "l", col = "red", lwd = 2)
+lines(true_returns, type = "l", col = "green", lwd = 2)
+legend("topright", legend = c("Observed Prices", "Filtered Prices", "True Returns"),
+       col = c("blue", "red", "green"), lty = 1, lwd = 2)


### PR DESCRIPTION
62 This change addresses a silent failure occurring when optional metadata columns were missing. The pipeline now fails fast with a clear error message instead of producing incomplete outputs. This should make downstream issues easier to detect. Existing configurations continue to work as before.