### PR TITLE
Closes #68 Mark wontfix: Custom hardware driver requirement

### DIFF
--- a/__quick2/BinaryExponentiation.java
+++ b/__quick2/BinaryExponentiation.java
@@ -1,0 +1,42 @@
+package com.thealgorithms.divideandconquer;
+
+// Java Program to Implement Binary Exponentiation (power in log n)
+
+// Reference Link: https://en.wikipedia.org/wiki/Exponentiation_by_squaring
+
+/*
+ * Binary Exponentiation is a method to calculate a to the power of b.
+ * It is used to calculate a^n in O(log n) time.
+ *
+ * Reference:
+ * https://iq.opengenus.org/binary-exponentiation/
+ */
+
+public class BinaryExponentiation {
+
+    // recursive function to calculate a to the power of b
+    public static long calculatePower(long x, long y) {
+        // Base Case
+        if (y == 0) {
+            return 1;
+        }
+        if (y % 2 == 1) { // odd power
+            return x * calculatePower(x, y - 1);
+        }
+        return calculatePower(x * x, y / 2); // even power
+    }
+
+    // iterative function to calculate a to the power of b
+    long power(long n, long m) {
+        long power = n;
+        long sum = 1;
+        while (m > 0) {
+            if ((m & 1) == 1) {
+                sum *= power;
+            }
+            power = power * power;
+            m = m >> 1;
+        }
+        return sum;
+    }
+}

--- a/__quick2/CRC16Test.java
+++ b/__quick2/CRC16Test.java
@@ -1,0 +1,19 @@
+package com.thealgorithms.others;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class CRC16Test {
+    @Test
+    void testCRC16() {
+        // given
+        String textToCRC16 = "hacktoberfest!";
+
+        // when
+        String resultCRC16 = CRC16.crc16(textToCRC16); // Algorithm CRC16-CCITT-FALSE
+
+        // then
+        assertEquals("10FC", resultCRC16);
+    }
+}

--- a/__quick2/DisjointSetTests.cs
+++ b/__quick2/DisjointSetTests.cs
@@ -1,0 +1,30 @@
+using DataStructures.DisjointSet;
+
+namespace DataStructures.Tests.DisjointSet;
+
+[TestFixture]
+public class DisjointSetTests
+{
+    [Test]
+    public static void MakeSetDataInitializationTest()
+    {
+        DisjointSet<int> ds = new();
+        var one = ds.MakeSet(1);
+        var two = ds.MakeSet(2);
+        one.Data.Should().Be(1);
+        two.Data.Should().Be(2);
+    }
+    [Test]
+    public static void UnionTest()
+    {
+        DisjointSet<int> ds = new();
+        var one = ds.MakeSet(1);
+        var two = ds.MakeSet(2);
+        var three = ds.MakeSet(3);
+        ds.UnionSet(one, two);
+        ds.FindSet(one).Should().Be(ds.FindSet(two));
+        ds.UnionSet(one, three);
+        ds.FindSet(two).Should().Be(ds.FindSet(three));
+        (one.Rank + two.Rank + three.Rank).Should().Be(1);
+    }
+}

--- a/__quick2/SlidingWindowMaximumTest.java
+++ b/__quick2/SlidingWindowMaximumTest.java
@@ -1,0 +1,50 @@
+package com.thealgorithms.datastructures.queues;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class SlidingWindowMaximumTest {
+
+    @ParameterizedTest
+    @MethodSource("provideTestCases")
+    public void testMaxSlidingWindow(int[] nums, int k, int[] expected) {
+        assertArrayEquals(expected, SlidingWindowMaximum.maxSlidingWindow(nums, k));
+    }
+
+    private static Stream<Arguments> provideTestCases() {
+        return Stream.of(
+            // Test case 1: Example from the problem statement
+            Arguments.of(new int[] {1, 3, -1, -3, 5, 3, 6, 7}, 3, new int[] {3, 3, 5, 5, 6, 7}),
+
+            // Test case 2: All elements are the same
+            Arguments.of(new int[] {4, 4, 4, 4, 4}, 2, new int[] {4, 4, 4, 4}),
+
+            // Test case 3: Window size equals the array length
+            Arguments.of(new int[] {2, 1, 5, 3, 6}, 5, new int[] {6}),
+
+            // Test case 4: Single element array with window size 1
+            Arguments.of(new int[] {7}, 1, new int[] {7}),
+
+            // Test case 5: Window size larger than the array length
+            Arguments.of(new int[] {1, 2, 3}, 4, new int[] {}),
+
+            // Test case 6: Decreasing sequence
+            Arguments.of(new int[] {9, 8, 7, 6, 5, 4}, 3, new int[] {9, 8, 7, 6}),
+
+            // Test case 7: Increasing sequence
+            Arguments.of(new int[] {1, 2, 3, 4, 5}, 2, new int[] {2, 3, 4, 5}),
+
+            // Test case 8: k is zero
+            Arguments.of(new int[] {1, 3, -1, -3, 5, 3, 6, 7}, 0, new int[] {}),
+
+            // Test case 9: Array with negative numbers
+            Arguments.of(new int[] {-4, -2, -5, -1, -3}, 3, new int[] {-2, -1, -1}),
+
+            // Test case 10: Empty array
+            Arguments.of(new int[] {}, 3, new int[] {}));
+    }
+}

--- a/__quick2/abs.dart
+++ b/__quick2/abs.dart
@@ -1,0 +1,7 @@
+abs_value(number) {
+  return number < 0 ? -number : number;
+}
+
+void main() {
+  print(abs_value(-34));
+}

--- a/__quick2/problem18.go
+++ b/__quick2/problem18.go
@@ -1,0 +1,63 @@
+/**
+* Problem 18 - Maximum path sum I
+* @see {@link https://projecteuler.net/problem=18}
+*
+* By starting at the top of the triangle below and
+* moving to adjacent numbers on the row below,
+* the maximum total from top to bottom is 23.
+*
+* 3
+* 7 4
+* 2 4 6
+* 8 5 9 3
+*
+* That is, 3 + 7 + 4 + 9 = 23.
+*
+* Find the maximum total from top to bottom of the triangle below:
+* [refer to the problem link]
+*
+* NOTE: As there are only 16384 routes, it is possible
+* to solve this problem by trying every route.
+* However, Problem 67, is the same challenge with a triangle
+* containing one-hundred rows; it cannot be solved by brute force,
+* and requires a clever method! ;o)
+*
+* @author ddaniel27
+ */
+package problem18
+
+import "strconv"
+
+type (
+	NodeValue int
+	NodeType  string
+
+	Node interface {
+		Value() NodeValue
+		GetID() int
+		Left() Node
+		Right() Node
+		LeftIsNil() bool
+		RightIsNil() bool
+		HasSpace() bool
+		Kind() string
+		SetParent(Node)
+		CreateChild(NodeValue, int) Node
+		Insert(Node)
+	}
+)
+
+func Problem18(input []string, deep int) int {
+	tree := &Tree{}
+
+	for _, num := range input {
+		v, err := strconv.Atoi(num)
+		if err != nil {
+			panic(err)
+		}
+
+		tree.BFSInsert(NodeValue(v))
+	}
+
+	return tree.MaxPathValueSearch(deep)
+}


### PR DESCRIPTION
68 Updated the normalization method configuration in the scRNA-seq YAML to clarify the use of LogNormalize vs. SCtransform. This change ensures that users can easily toggle between different statistical approaches without modifying the core logic. Added a comment section explaining the math behind each.