### PR TITLE
Closes #77 Fix checkpoint resume logic to ensure consistent metric computation

### DIFF
--- a/__exp8/093_levenstein_Scala.scala
+++ b/__exp8/093_levenstein_Scala.scala
@@ -1,0 +1,32 @@
+import scala.io.StdIn.readLine
+
+object Levenshtein {
+  def compute(s1: String, s2: String): Int = {
+    val m = s1.length
+    val n = s2.length
+    val dp = Array.ofDim[Int](m + 1, n + 1)
+
+    for (i <- 0 to m) dp(i)(0) = i
+    for (j <- 0 to n) dp(0)(j) = j
+
+    for (i <- 1 to m) {
+      for (j <- 1 to n) {
+        val cost = if (s1(i - 1) == s2(j - 1)) 0 else 1
+        dp(i)(j) = Seq(
+          dp(i - 1)(j) + 1,       // deletion
+          dp(i)(j - 1) + 1,       // insertion
+          dp(i - 1)(j - 1) + cost // substitution
+        ).min
+      }
+    }
+
+    dp(m)(n)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val s1 = readLine()
+    val s2 = readLine()
+    println(compute(s1, s2))
+  }
+}
+

--- a/__exp8/Helper.cs
+++ b/__exp8/Helper.cs
@@ -1,0 +1,28 @@
+namespace Algorithms.Tests.Search;
+
+public static class Helper
+{
+    public static int[] GetSortedArray(int length) =>
+        Enumerable.Range(0, length)
+            .Select(_ => TestContext.CurrentContext.Random.Next(1_000_000))
+            .OrderBy(x => x)
+            .ToArray();
+
+    public static int GetItemIn(int[] arr) => arr[TestContext.CurrentContext.Random.Next(arr.Length)];
+
+    public static int GetItemNotIn(int[] arr)
+    {
+        int item;
+        do
+        {
+            item = TestContext.CurrentContext.Random.Next(arr.Min(), arr.Max() + 1);
+        }
+        while (arr.Contains(item));
+
+        return item;
+    }
+
+    public static int GetItemSmallerThanAllIn(int[] arr) => arr.Min() - 1;
+
+    public static int GetItemBiggerThanAllIn(int[] arr) => arr.Max() + 1;
+}

--- a/__exp8/PerfectCubeChecker.cs
+++ b/__exp8/PerfectCubeChecker.cs
@@ -1,0 +1,58 @@
+namespace Algorithms.Numeric;
+
+/// <summary>
+///     A perfect cube is an element of algebraic structure that is equal to the cube of another element.
+/// </summary>
+public static class PerfectCubeChecker
+{
+    /// <summary>
+    ///     Checks if a number is a perfect cube or not.
+    /// </summary>
+    /// <param name="number">Number to check.</param>
+    /// <returns>True if is a perfect cube; False otherwise.</returns>
+    public static bool IsPerfectCube(int number)
+    {
+        if (number < 0)
+        {
+            number = -number;
+        }
+
+        var cubeRoot = Math.Round(Math.Pow(number, 1.0 / 3.0));
+        return Math.Abs(cubeRoot * cubeRoot * cubeRoot - number) < 1e-6;
+    }
+
+    /// <summary>
+    ///     Checks if a number is a perfect cube or not using binary search.
+    /// </summary>
+    /// <param name="number">Number to check.</param>
+    /// <returns>True if is a perfect cube; False otherwise.</returns>
+    public static bool IsPerfectCubeBinarySearch(int number)
+    {
+        if (number < 0)
+        {
+            number = -number;
+        }
+
+        int left = 0;
+        int right = number;
+        while (left <= right)
+        {
+            int mid = left + (right - left) / 2;
+            int midCubed = mid * mid * mid;
+            if (midCubed == number)
+            {
+                return true;
+            }
+            else if (midCubed < number)
+            {
+                left = mid + 1;
+            }
+            else
+            {
+                right = mid - 1;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
77 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.